### PR TITLE
*Always* ignore .jekyll-metadata, even if it doesn't exist.

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -53,21 +53,14 @@ module Jekyll
     end
 
     def config_files(options)
-      %w[
-        _config.yml
-        _config.yaml
-        _config.toml
-      ].map { |config_file| Jekyll.sanitized_path(options['source'], config_file) }
-    end
-
-    def metadata_file(options)
-      Jekyll.sanitized_path(options['source'], '.jekyll-metadata')
+      %w[yml yaml toml].map do |ext|
+        Jekyll.sanitized_path(options['source'], "_config.#{ext}")
+      end
     end
 
     def to_exclude(options)
       [
         config_files(options),
-        metadata_file(options),
         options['destination'],
         custom_excludes(options)
       ].flatten
@@ -96,7 +89,7 @@ module Jekyll
             # Could not find a relative path
           end
         end
-      end.compact
+      end.compact + [/\.jekyll\-metadata/]
     end
 
   end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -8,7 +8,7 @@ describe(Jekyll::Watcher) do
     }
   end
   let(:options) { base_opts }
-  let(:default_ignored) { [/_config\.yml/, /\.jekyll\-metadata/, /_site/] }
+  let(:default_ignored) { [/_config\.yml/, /_site/, /\.jekyll\-metadata/] }
   subject { described_class }
   before(:each) do
     FileUtils.mkdir(options['destination']) if options['destination']
@@ -25,7 +25,7 @@ describe(Jekyll::Watcher) do
     end
 
     it "ignores the config and site by default" do
-      expect(listener.options[:ignore]).to eql([/_config\.yml/, /_site/])
+      expect(listener.options[:ignore]).to eql(default_ignored)
     end
 
     it "defaults to no force_polling" do
@@ -66,36 +66,40 @@ describe(Jekyll::Watcher) do
       end
     end
 
-    context "when source is absolute" do
-      context "when destination is absolute" do
-        let(:options) { base_opts.merge('destination' => source_dir('_dest')) }
-        it "ignores the destination" do
-          expect(ignored).to eql([/_config\.yml/, /\.jekyll\-metadata/, /_dest/])
+    context "with a custom destination" do
+      let(:default_ignored) { [/_config\.yml/, /_dest/, /\.jekyll\-metadata/] }
+
+      context "when source is absolute" do
+        context "when destination is absolute" do
+          let(:options) { base_opts.merge('destination' => source_dir('_dest')) }
+          it "ignores the destination" do
+            expect(ignored).to eql(default_ignored)
+          end
+        end
+
+        context "when destination is relative" do
+          let(:options) { base_opts.merge('destination' => 'spec/test-site/_dest') }
+          it "ignores the destination" do
+            expect(ignored).to eql(default_ignored)
+          end
         end
       end
 
-      context "when destination is relative" do
-        let(:options) { base_opts.merge('destination' => 'spec/test-site/_dest') }
-        it "ignores the destination" do
-          expect(ignored).to eql([/_config\.yml/, /\.jekyll\-metadata/, /_dest/])
+      context "when source is relative" do
+        let(:base_opts) { {'source' => Pathname.new(source_dir).relative_path_from(Pathname.new('.').expand_path).to_s } }
+
+        context "when destination is absolute" do
+          let(:options) { base_opts.merge('destination' => source_dir('_dest')) }
+          it "ignores the destination" do
+            expect(ignored).to eql(default_ignored)
+          end
         end
-      end
-    end
 
-    context "when source is relative" do
-      let(:base_opts) { {'source' => Pathname.new(source_dir).relative_path_from(Pathname.new('.').expand_path).to_s } }
-
-      context "when destination is absolute" do
-        let(:options) { base_opts.merge('destination' => source_dir('_dest')) }
-        it "ignores the destination" do
-          expect(ignored).to eql([/_config\.yml/, /\.jekyll\-metadata/, /_dest/])
-        end
-      end
-
-      context "when destination is relative" do
-        let(:options) { base_opts.merge('destination' => 'spec/test-site/_dest') }
-        it "ignores the destination" do
-          expect(ignored).to eql([/_config\.yml/, /\.jekyll\-metadata/, /_dest/])
+        context "when destination is relative" do
+          let(:options) { base_opts.merge('destination' => 'spec/test-site/_dest') }
+          it "ignores the destination" do
+            expect(ignored).to eql(default_ignored)
+          end
         end
       end
     end


### PR DESCRIPTION
Addresses [this comment](https://github.com/jekyll/jekyll-watch/pull/15#issuecomment-65860347):

> Edge case bug I just realized: the first time the site is run with jekyll [blah] --watch, it'll continuously regenerate because it doesn't add .jekyll-metadata unless it's there.

Follow-up to #15.
