### PR TITLE
Show regen time & use the same Site object across regens

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -34,13 +34,13 @@ module Jekyll
 
     def listen_handler(site)
       proc { |modified, added, removed|
-        t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+        t = Time.now
         c = modified + added + removed
         n = c.length
-        print Jekyll.logger.message("Regenerating:", "#{n} files at #{t} ")
+        print Jekyll.logger.message("Regenerating:", "#{n} file changed at #{t.strftime("%Y-%m-%d %H:%M:%S")} ")
         begin
-          puts  "...done."
           site.process
+          puts  "...done in #{Time.now - t} seconds."
         rescue => e
           puts "...error:"
           Jekyll.logger.warn "Error:", e.message

--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -37,7 +37,7 @@ module Jekyll
         t = Time.now
         c = modified + added + removed
         n = c.length
-        print Jekyll.logger.message("Regenerating:", "#{n} file changed at #{t.strftime("%Y-%m-%d %H:%M:%S")} ")
+        print Jekyll.logger.message("Regenerating:", "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")} ")
         begin
           site.process
           puts  "...done in #{Time.now - t} seconds."

--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -3,7 +3,8 @@ module Jekyll
     extend self
 
     def watch(options)
-      listener = build_listener(options)
+      site = Jekyll::Site.new(options)
+      listener = build_listener(site, options)
       listener.start
 
       Jekyll.logger.info "Auto-regeneration:", "enabled for '#{options['source']}'"
@@ -21,25 +22,25 @@ module Jekyll
       # You pressed Ctrl-C, oh my!
     end
 
-    def build_listener(options)
+    def build_listener(site, options)
       require 'listen'
       Listen.to(
         options['source'],
         :ignore => listen_ignore_paths(options),
         :force_polling => options['force_polling'],
-        &(listen_handler(options))
+        &(listen_handler(site))
       )
     end
 
-    def listen_handler(options)
+    def listen_handler(site)
       proc { |modified, added, removed|
         t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
         c = modified + added + removed
         n = c.length
         print Jekyll.logger.message("Regenerating:", "#{n} files at #{t} ")
         begin
-          Jekyll::Command.process_site(Jekyll::Site.new(options))
           puts  "...done."
+          site.process
         rescue => e
           puts "...error:"
           Jekyll.logger.warn "Error:", e.message

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,4 +71,11 @@ RSpec.configure do |config|
   def dest_dir(*files)
     source_dir('_site', *files)
   end
+
+  def site_from_options(options)
+    Jekyll::Site.new(Jekyll::Utils.deep_merge_hashes(
+      Jekyll::Configuration::DEFAULTS,
+      options
+    ))
+  end
 end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -8,6 +8,7 @@ describe(Jekyll::Watcher) do
     }
   end
   let(:options) { base_opts }
+  let(:site)    { site_from_options(options) }
   let(:default_ignored) { [/_config\.yml/, /_site/, /\.jekyll\-metadata/] }
   subject { described_class }
   before(:each) do
@@ -18,7 +19,7 @@ describe(Jekyll::Watcher) do
   end
 
   context "#build_listener" do
-    let(:listener) { subject.build_listener(options) }
+    let(:listener) { subject.build_listener(site, options) }
 
     it "returns a Listen::Listener" do
       expect(listener).to be_a(Listen::Listener)
@@ -34,7 +35,6 @@ describe(Jekyll::Watcher) do
 
     context "with force_polling turned on" do
       let(:options)  { base_opts.merge('force_polling' => true) }
-      let(:listener) { subject.build_listener(options) }
 
       it "respects the custom value of force_polling" do
         expect(listener.options[:force_polling]).to be(true)


### PR DESCRIPTION
Example output:

```text
Configuration file: /Users/parker/jekyll/jekyll/site/_config.yml
            Source: /Users/parker/jekyll/jekyll/site
       Destination: /Users/parker/jekyll/jekyll/site/_site
 Incremental build: enabled
      Generating...
                    done.
 Auto-regeneration: enabled for '/Users/parker/jekyll/jekyll/site'
Configuration file: /Users/parker/jekyll/jekyll/site/_config.yml
    Server address: http://127.0.0.1:4000/
  Server running... press ctrl-c to stop.
      Regenerating: 1 files changed at 2015-01-13 13:39:06 ...done in 16.245954 seconds.
```