### PR TITLE
Don't just ignore everything that containts the ignore paths

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -82,7 +82,12 @@ module Jekyll
           begin
             relative_path = absolute_path.relative_path_from(source).to_s
             unless relative_path.start_with?('../')
-              path_to_ignore = Regexp.new(Regexp.escape(relative_path))
+              if File.directory?(relative_path)
+                path_to_ignore = Regexp.new("^#{Regexp.escape(relative_path)}\/")
+              else
+                path_to_ignore = Regexp.new("^#{Regexp.escape(relative_path)}$")
+              end
+
               Jekyll.logger.debug "Watcher:", "Ignoring #{path_to_ignore}"
               path_to_ignore
             end
@@ -90,7 +95,7 @@ module Jekyll
             # Could not find a relative path
           end
         end
-      end.compact + [/\.jekyll\-metadata/]
+      end.compact + [/^\.jekyll\-metadata$/]
     end
 
   end


### PR DESCRIPTION
Spend my first thing I've done with Ruby with this little boy. The issue was that we were telling listen to ignore everything that _contained_ the ignore paths (like `_site`). Every file that had the same string in it was not being watched by listen.

I've came to the conclusion that I needed something lightly different for files and directories, but there probably are ways without it.

- Ignored Directories (e.g. _site): Regex should match paths that start with `_site`
- Ignored files (e.g. _config.yml, .jekyll-metadata): Regex should match paths that match the relative path exactly

Phew, this took me so long. Do we need additional tests?

Ah, yes. Fixes #22 in the case I did nothing wrong. :rocket: 