### PR TITLE
lock to Listen 3.x

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
 require "bundler/gem_tasks"
 
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.verbose = false
+end
+
+task default: :spec

--- a/jekyll-watch.gemspec
+++ b/jekyll-watch.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "listen", "~> 2.7"
+  spec.add_runtime_dependency "listen", "~> 3.0"
 
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/

--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -1,3 +1,5 @@
+require 'listen'
+
 module Jekyll
   module Watcher
     extend self
@@ -16,14 +18,14 @@ module Jekyll
           exit 0
         end
 
-        loop { sleep 1000 }
+        sleep_forever
       end
     rescue ThreadError => e
       # You pressed Ctrl-C, oh my!
     end
 
+    # TODO: shouldn't be public API
     def build_listener(site, options)
-      require 'listen'
       Listen.to(
         options['source'],
         :ignore => listen_ignore_paths(options),
@@ -93,5 +95,8 @@ module Jekyll
       end.compact + [/\.jekyll\-metadata/]
     end
 
+    def sleep_forever
+      loop { sleep 1000 }
+    end
   end
 end

--- a/script/test
+++ b/script/test
@@ -1,3 +1,2 @@
 #!/bin/bash
-
-bundle exec rspec --color --require spec_helper "$@"
+bundle exec rspec "$@"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,11 +71,4 @@ RSpec.configure do |config|
   def dest_dir(*files)
     source_dir('_site', *files)
   end
-
-  def site_from_options(options)
-    Jekyll::Site.new(Jekyll::Utils.deep_merge_hashes(
-      Jekyll::Configuration::DEFAULTS,
-      options
-    ))
-  end
 end


### PR DESCRIPTION
Listen 3.x includes the following:
- better performance (especially with Polling)
- less dependencies (no Celluloid, Celluloid::IO, Timers, TCP, etc.)
- less resource usage (threads, CPU, memory)
- cleaner codebase
- API differences are irrelevant to jekyll-watch