### PR TITLE
Fix #37: Lock Listen to less than 3.1.

### DIFF
--- a/jekyll-watch.gemspec
+++ b/jekyll-watch.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # XXX: Remove the lock with Jekyll 4 or in 2017 when Ruby 2.1 goes EOL.
   spec.add_runtime_dependency "listen", "~> 3.0", "< 3.1"
 
   require 'rbconfig'

--- a/jekyll-watch.gemspec
+++ b/jekyll-watch.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "listen", "~> 3.0"
+  spec.add_runtime_dependency "listen", "~> 3.0", "< 3.1"
 
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/


### PR DESCRIPTION
Jekyll supports 2.1+ but @e2 has made it so that Listen only supports
2.2 so this locks it so that we are on a version of Listen that we can
actually support since we still support all supporte Ruby versions.