### PR TITLE
Update versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-- 2.0
-- 2.1
-- 2.2
-matrix:
-  include:
-    - rvm: 1.9.3
-      env: JEKYLL_VERSION=2.5
+- 2.1.9
+- 2.2.5
+- 2.3.1
 env:
   matrix:
-    - JEKYLL_VERSION=2.5
     - JEKYLL_VERSION=3.0
 branches:
   only:


### PR DESCRIPTION
- Run Travis with Ruby versions currently tested on jekyll/jekyll
- Stop testing for Jekyll 2 