### PR TITLE
Anchor excludes to start of string. Fixes #44.

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -99,14 +99,14 @@ module Jekyll
         begin
           relative_path = absolute_path.relative_path_from(source).to_s
           unless relative_path.start_with?('../')
-            path_to_ignore = Regexp.new(Regexp.escape(relative_path))
+            path_to_ignore = Regexp.new("^" + Regexp.escape(relative_path))
             Jekyll.logger.debug "Watcher:", "Ignoring #{path_to_ignore}"
             path_to_ignore
           end
         rescue ArgumentError
           # Could not find a relative path
         end
-      end.compact + [/\.jekyll\-metadata/]
+      end.compact + [/^\.jekyll\-metadata/]
     end
 
     def sleep_forever

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -10,7 +10,7 @@ describe(Jekyll::Watcher) do
 
   let(:options) { base_opts }
   let(:site)    { instance_double(Jekyll::Site) }
-  let(:default_ignored) { [/_config\.yml/, /_site/, /\.jekyll\-metadata/] }
+  let(:default_ignored) { [/^_config\.yml/, /^_site/, /^\.jekyll\-metadata/] }
   subject { described_class }
   before(:each) do
     FileUtils.mkdir(options['destination']) if options['destination']
@@ -104,13 +104,13 @@ describe(Jekyll::Watcher) do
       after(:each)  { FileUtils.rm(excluded_absolute) }
 
       it "ignores the excluded files" do
-        expect(ignored).to include(/README\.md/)
-        expect(ignored).to include(/LICENSE/)
+        expect(ignored).to include(/^README\.md/)
+        expect(ignored).to include(/^LICENSE/)
       end
     end
 
     context "with a custom destination" do
-      let(:default_ignored) { [/_config\.yml/, /_dest/, /\.jekyll\-metadata/] }
+      let(:default_ignored) { [/^_config\.yml/, /^_dest/, /^\.jekyll\-metadata/] }
 
       context "when source is absolute" do
         context "when destination is absolute" do


### PR DESCRIPTION
Before this change, excluding a directory (`bin`) would also exclude posts
that include that name (`scrubbing`), which is very unexpected.

While this may start listening to files that were previously ignored, it
more closely matches the behaviour of jekyll on it's initial build
(which _would_ include `scrubbing`).  The consequences of being overly
aggressive on listening to changes seem less important than missing
something.

This change is a bandaid. A proper fix would be to unify with Jekyll's
exclusion logic (Jekyll::EntryFilter maybe?) to ensure they will always
be the same. In the meantime, it _may_ be advisable to not include
Jekyll's `exclude` config in the watchers ignore list and take the hit
of overly aggressive reloads. I leave that decision to someone more
experienced than I.