### PR TITLE
Remove version lock for dependency listen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
 - 2.2.5
 - 2.3.1
+- 2.4.2
 env:
   matrix:
     - JEKYLL_VERSION=3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2.5
-- 2.3.1
-- 2.4.2
+- 2.2
+- 2.3
+- 2.4
 env:
   matrix:
     - JEKYLL_VERSION=3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.1.9
 - 2.2.5
 - 2.3.1
 env:

--- a/jekyll-watch.gemspec
+++ b/jekyll-watch.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # XXX: Remove the lock with Jekyll 4 or in 2017 when Ruby 2.1 goes EOL.
-  spec.add_runtime_dependency "listen", "~> 3.0", "< 3.1"
+  spec.add_runtime_dependency "listen", "~> 3.0"
 
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/


### PR DESCRIPTION
As Ruby 2.1 has reached its end of life end of March 2017, locking listen to versions prior to 3.1 should no longer be necessary.

Please adjust my change if you see fit 😃.

I just wanted to make sure that this to-do is addressed at some point, because I currently have trouble running Jekyll on Arch Linux due to the recent upgrade of listen to 3.1.5 in the AUR (Ruby now fails while checking the dependency to listen, since it is still declared as `< 3.1`).