### PR TITLE
Output regenerated file paths to terminal

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -58,7 +58,7 @@ module Jekyll
         Jekyll.logger.info "Regenerating:",
           "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")}"
 
-        c.map { |path| path.sub(site.source, "") }.each do |file|
+        c.map { |path| path.sub("#{site.source}/", "") }.each do |file|
           Jekyll.logger.info "", file
         end
 

--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -58,7 +58,7 @@ module Jekyll
         Jekyll.logger.info "Regenerating:",
           "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")}"
 
-        c.map { |path| site.in_source_dir(path) }.each do |file|
+        c.map { |path| path.sub(site.source, "") }.each do |file|
           Jekyll.logger.info "", file
         end
 

--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -55,16 +55,14 @@ module Jekyll
         t = Time.now
         c = modified + added + removed
         n = c.length
-        print Jekyll.logger.message("Regenerating:",
-          "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")} ")
-        begin
-          site.process
-          puts "...done in #{Time.now - t} seconds."
-        rescue => e
-          puts "...error:"
-          Jekyll.logger.warn "Error:", e.message
-          Jekyll.logger.warn "Error:", "Run jekyll build --trace for more information."
+        Jekyll.logger.info "Regenerating:",
+          "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")}"
+
+        c.map { |path| site.in_source_dir(path) }.each do |file|
+          Jekyll.logger.info "", file
         end
+
+        process(site, t)
       end
     end
 
@@ -113,6 +111,18 @@ module Jekyll
 
     def sleep_forever
       loop { sleep 1000 }
+    end
+
+    private
+    def process(site, time)
+      begin
+        site.process
+        Jekyll.logger.info "", "...done in #{Time.now - time} seconds."
+      rescue => e
+        Jekyll.logger.warn "Error:", e.message
+        Jekyll.logger.warn "Error:", "Run jekyll build --trace for more information."
+      end
+      puts ""
     end
   end
 end


### PR DESCRIPTION
With this, the plugin outputs the full path(s) of the regenerated files, in addition to the existing total count of regenerated files