### PR TITLE
Allow users on Ruby 2.1 to continue with v1.x

### DIFF
--- a/jekyll-watch.gemspec
+++ b/jekyll-watch.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_runtime_dependency "listen", "~> 3.0"
+  spec.add_runtime_dependency "listen",
+    RUBY_VERSION < "2.2.5" ? ("~> 3.0", "< 3.1") : "~> 3.0"
 
   require "rbconfig"
   if RbConfig::CONFIG["host_os"] =~ %r!mswin|mingw|cygwin!


### PR DESCRIPTION
**For `v1.x` series**

`v1.5.1` was released with support to load `listen-3.1.x` which isn't supported on Ruby 2.1.x.

This patch restores the version-lock for users using Ruby older than 2.2.5 (since listen requires atleast that version, owing to a security fix released with Ruby 2.2.5)