### PR TITLE
Replace non-existent local variable

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -60,7 +60,7 @@ module Jekyll
         Jekyll.logger.info "Regenerating:",
                            "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")}"
 
-        c.each { |path| Jekyll.logger.info "", path.sub("#{source_path}/", "") }
+        c.each { |path| Jekyll.logger.info "", path.sub("#{site.source}/", "") }
         process(site, t)
       end
     end


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll/issues/7308
Fixes #75 

Fix bug introduced by #69 

## Context

The local variable **should've been removed** while resolving conflicts in the PR branch in https://github.com/jekyll/jekyll-watch/pull/69/commits/6a065e3e05ddb5b8569991f82df8d9dafbff1169