### PR TITLE
Fix encoding discrepancy in excluded Windows paths

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -65,8 +65,13 @@ module Jekyll
       end
     end
 
-    def normalize_encoding(list, desired_encoding)
-      list.map { |entry| entry.encode!(desired_encoding, entry.encoding) }
+    def normalize_encoding(obj, desired_encoding)
+      case obj
+      when Array
+        obj.map { |entry| entry.encode!(desired_encoding, entry.encoding) }
+      when String
+        obj.encode!(desired_encoding, obj.encoding)
+      end
     end
 
     def custom_excludes(options)
@@ -97,7 +102,7 @@ module Jekyll
       paths  = to_exclude(options)
 
       paths.map do |p|
-        absolute_path = Pathname.new(p).expand_path
+        absolute_path = Pathname.new(normalize_encoding(p, options["source"].encoding)).expand_path
         next unless absolute_path.exist?
 
         begin


### PR DESCRIPTION
## Summary
When a site is in a directory containing characters with accents and similar entities (e.g., `testé-çasésûr`),
the paths were encoded differently which were seen as a separate directory in the site.

## Context

https://github.com/jekyll/jekyll-watch/blob/adc010795c4f5536b3e6961954a68ea8d41a5de4/lib/jekyll/watcher.rb#L95-L105

If I were to have a custom destination set to "public", then the `absolute_path` in the code above gets created with encoding `Encoding:UTF-8` while the `options["source"]` encoding was in
`Encoding:Windows-1252`.
This resulted in a "relative_path" (via Pathname) starting with `../` which caused **that path to not be included as an ignored_path**
```
#<Pathname:D:/testAc-A§asAcsA»r/public>
#<Pathname:../testAc-A§asAcsA»r/public>
```
or when stringified:
```
D:/testAc-A§asAcsA»r/public
../testAc-A§asAcsA»r/public
```

### Steps to reproduce issue (Windows only)
- Create a site with accents in the path: `jekyll new testé-çasésûr`
- Add a custom `destination` configuration (regular string)
    ```yaml
    destination: public
    ```
- Watch the site: `bundle exec jekyll b --watch` or `bundle exec jekyll s`
- Make a change in any file..

/cc @jekyll/windows 

## Thanks

To @DirtyF for providing a test repository that led to the discovery of this bug