### PR TITLE
Fix watcher failure due to incorrect file name encoding

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -54,19 +54,15 @@ module Jekyll
     def listen_handler(site)
       proc do |modified, added, removed|
         t = Time.now
-        c = normalize_encoding(modified + added + removed, site.source.encoding)
+        c = modified + added + removed
         n = c.length
 
         Jekyll.logger.info "Regenerating:",
                            "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")}"
 
-        c.each { |path| Jekyll.logger.info "", path.sub("#{site.source}/", "") }
+        c.each { |path| Jekyll.logger.info "", path["#{site.source}/".length..-1] }
         process(site, t)
       end
-    end
-
-    def normalize_encoding(list, desired_encoding)
-      list.map { |entry| entry.encode!(desired_encoding, entry.encoding) }
     end
 
     def custom_excludes(options)

--- a/spec/test-sité/_posts/2014-08-08-歡迎使用jekyll.markdown
+++ b/spec/test-sité/_posts/2014-08-08-歡迎使用jekyll.markdown
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "歡迎使用Jekyll"
+date:   2014-08-08 18:00:36
+categories: jekyll update
+---
+你會在你的`_posts`目錄中找到這篇文章 - 編輯它並重新構建（或使用`--watch`開關運行）來查看你的更改。
+
+要添加新帖子，只需在`_posts`目錄中添加一個文件，該文件遵循慣例`YYYY-MM-DD-name-of-post.ext`並包含必要的前置事項。 看看這篇文章的來源，了解它的工作原理。
+
+Jekyll還為代碼片段提供強大的支持：
+
+{% highlight ruby %}
+def print_hi(name)
+  puts "Hi, #{name}"
+end
+print_hi('Tom')
+#=> prints 'Hi, Tom' to STDOUT.
+{% endhighlight %}
+
+查看[Jekyll docs] [jekyll]了解更多關於如何充分利用Jekyll的信息。 在[Jekyll的GitHub repo] [jekyll-gh]提交所有錯誤/功能請求。 如果您有疑問，可以在[Jekyll的專用幫助存儲庫] [jekyll-help]上詢問。
+
+[jekyll]:      http://jekyllrb.com
+[jekyll-gh]:   https://github.com/jekyll/jekyll
+[jekyll-help]: https://github.com/jekyll/jekyll-help


### PR DESCRIPTION
When the watched file name isn't US-ASCII encoded (i.e. UTF-8), the watcher will raise error when file modification is made:

```
processing events: U+6211 from UTF-8 to US-ASCII Backtrace:

[2018-10-13T15:17:43.736524 #83757] ERROR -- : exception while processing events: U+6211 from UTF-8 to US-ASCII Backtrace:
 -- .rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/jekyll-watch-2.1.1/lib/jekyll/watcher.rb:71:in `encode!'
 -- .rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/jekyll-watch-2.1.1/lib/jekyll/watcher.rb:71:in `block in normalize_encoding'
 -- .rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/jekyll-watch-2.1.1/lib/jekyll/watcher.rb:71:in `map'
 -- .rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/jekyll-watch-2.1.1/lib/jekyll/watcher.rb:71:in `normalize_encoding'
 -- .rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/jekyll-watch-2.1.1/lib/jekyll/watcher.rb:59:in `block in listen_handler'
```

The issue is fixed by avoiding the need for encoding conversion when watcher outputting log to the console.

__Steps to reproduce__
- Create a post with file name "2018-01-01-夏天.markdown"
- Run jekyll (`bundle exec jekyll serve`)
- Make any modification to the post file to trigger file change event, and error will be raised.
