### PR TITLE
Add basic glob support to Watcher module

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -100,9 +100,13 @@ module Jekyll
     def listen_ignore_paths(options)
       source = Pathname.new(options["source"]).expand_path
       paths  = to_exclude(options)
+      convert_to_regex(paths, options, source).compact + [%r!^\.jekyll\-metadata!]
+    end
 
-      paths.map do |p|
+    def convert_to_regex(paths, options, source)
+      paths.flat_map do |p|
         absolute_path = Pathname.new(normalize_encoding(p, options["source"].encoding)).expand_path
+        next convert_to_regex(Dir.glob(p), options, source) if p.include?("*")
         next unless absolute_path.exist?
 
         begin
@@ -116,7 +120,7 @@ module Jekyll
         rescue ArgumentError
           # Could not find a relative path
         end
-      end.compact + [%r!^\.jekyll\-metadata!]
+      end
     end
 
     def sleep_forever

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -126,6 +126,35 @@ describe(Jekyll::Watcher) do
       end
     end
 
+    context "with excluded globs" do
+      let(:excluded) { ["foo/**/*"] }
+      let(:excluded_relative_paths) do
+        ["foo/bar/sit.md", "foo/lore/sit.md", "foo/barsite.md"]
+      end
+      let(:excluded_absolute_dirs) do
+        ["foo", "foo/bar", "foo/lore"].map do |path|
+          Jekyll.sanitized_path(options["source"], path)
+        end
+      end
+      let(:excluded_absolute_files) do
+        excluded_relative_paths.map { |p| Jekyll.sanitized_path(options["source"], p) }
+      end
+      let(:options) { base_opts.merge("exclude" => excluded) }
+      before(:each) do
+        FileUtils.mkdir_p(excluded_absolute_dirs)
+        FileUtils.touch(excluded_absolute_files)
+      end
+      after(:each) do
+        FileUtils.rm_rf(excluded_absolute_files + excluded_absolute_dirs)
+      end
+
+      it "ignores the excluded files" do
+        excluded_relative_paths.each do |path|
+          expect(ignore_path?(ignored, path)).to eql(true)
+        end
+      end
+    end
+
     context "with a custom destination" do
       let(:default_ignored) { [%r!^_config\.yml!, %r!^_dest/!, %r!^\.jekyll\-metadata!] }
 


### PR DESCRIPTION
If users list a glob pattern in the `exclude` config, expand the pattern and exclude the resulting set of paths.

**Currently limited to glob patterns involving just `*`**

Resolves #90 
Closes #91 
Closes #92 

/cc @mohkale