### PR TITLE
Prevent `SystemExit` from raising exception

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -36,7 +36,7 @@ module Jekyll
 
         sleep_forever
       end
-    rescue ThreadError
+    rescue ThreadError, SystemExit
       # You pressed Ctrl-C, oh my!
     end
 


### PR DESCRIPTION
Prevent `SystemExit` (which is caused by `exit 0`) from raising exception.