### PR TITLE
Ignore missing files

### DIFF
--- a/lib/jekyll/watcher.rb
+++ b/lib/jekyll/watcher.rb
@@ -103,11 +103,12 @@ module Jekyll
 
       paths.map do |p|
         absolute_path = Pathname.new(normalize_encoding(p, options["source"].encoding)).expand_path
-        next unless absolute_path.exist?
 
         begin
           relative_path = absolute_path.relative_path_from(source).to_s
-          relative_path = File.join(relative_path, "") if absolute_path.directory?
+          if (absolute_path.exist? && absolute_path.directory?) || p.end_with?("/")
+            relative_path = File.join(relative_path, "")
+          end
           unless relative_path.start_with?("../")
             path_to_ignore = %r!^#{Regexp.escape(relative_path)}!
             Jekyll.logger.debug "Watcher:", "Ignoring #{path_to_ignore}"

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -10,7 +10,8 @@ describe(Jekyll::Watcher) do
 
   let(:options) { base_opts }
   let(:site)    { instance_double(Jekyll::Site) }
-  let(:default_ignored) { [%r!^_config\.yml!, %r!^_site/!, %r!^\.jekyll\-metadata!] }
+  let(:config_files)    { [%r!^_config\.yml!, %r!^_config\.yaml!, %r!^_config\.toml!] }
+  let(:default_ignored) { config_files + [%r!^_site/!, %r!^\.jekyll\-metadata!] }
   subject { described_class }
   before(:each) do
     FileUtils.mkdir(options["destination"]) if options["destination"]
@@ -127,7 +128,7 @@ describe(Jekyll::Watcher) do
     end
 
     context "with a custom destination" do
-      let(:default_ignored) { [%r!^_config\.yml!, %r!^_dest/!, %r!^\.jekyll\-metadata!] }
+      let(:default_ignored) { config_files + [%r!^_dest/!, %r!^\.jekyll\-metadata!] }
 
       context "when source is absolute" do
         context "when destination is absolute" do


### PR DESCRIPTION
### Summary

While playing with one of my Jekyll projects, I noticed that directories are not actually excluded from being watched if they're missing before `jekyll serve` is run (even though they're present in _config.yml's `exclude` array). As the example of .jekyll-metadata shows, it's possible to actually ignored missing directories; this PR attempts to implement this.

### Testing

* `bundle exec rspec` passes.